### PR TITLE
Switch to @material-ui/styles styling solution

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -2,7 +2,7 @@
 
 const React = require("react"),
   { renderToString } = require("react-dom/server"),
-  JssProvider = require("react-jss/lib/JssProvider").default,
+  StylesProvider = require("@material-ui/styles/StylesProvider").default,
   getPageContext = require("./src/utils/getPageContext").default;
 
 function replaceRenderer({
@@ -13,9 +13,9 @@ function replaceRenderer({
   // Get the context of the page to collected side effects.
   const muiPageContext = getPageContext(),
     bodyHTML = renderToString(
-      <JssProvider registry={muiPageContext.sheetsRegistry}>
+      <StylesProvider sheetsRegistry={muiPageContext.sheetsRegistry}>
         {bodyComponent}
-      </JssProvider>
+      </StylesProvider>
     );
 
   replaceBodyHTMLString(bodyHTML);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^3.9.3",
+    "@material-ui/styles": "^3.0.0-alpha.10",
     "gatsby": "^2.3.6",
     "gatsby-plugin-react-helmet": "^3.0.11",
     "gatsby-plugin-remove-serviceworker": "^1.0.0",

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -3,8 +3,15 @@ import Card from "@material-ui/core/Card";
 import CardHeader from "@material-ui/core/CardHeader";
 import CardContent from "@material-ui/core/CardContent";
 import CardActions from "@material-ui/core/CardActions";
+import withStyles from '@material-ui/styles/withStyles';
 
-const MyCard = ({ children, title, subheader, avatar, action, style = {} }) => (
+const styles = {
+  cardActions: {
+    float: 'right'
+  }
+};
+
+const MyCard = ({ children, classes, title, subheader, avatar, action, style = {} }) => (
   <Card style={style}>
     <CardHeader
       avatar={avatar ? avatar : null}
@@ -12,8 +19,8 @@ const MyCard = ({ children, title, subheader, avatar, action, style = {} }) => (
       subheader={subheader ? subheader : null}
     />
     <CardContent>{children}</CardContent>
-    <CardActions style={{ float: "right" }}>{action}</CardActions>
+    <CardActions className={classes.cardActions}>{action}</CardActions>
   </Card>
 );
 
-export default MyCard;
+export default withStyles(styles)(MyCard);

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "gatsby";
+import { Link, withPrefix } from "gatsby";
 import MobileStepper from "@material-ui/core/MobileStepper";
 import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
@@ -9,9 +9,15 @@ import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import CardMedia from "@material-ui/core/CardMedia";
 import { autoPlay } from "react-swipeable-views-utils";
-import { withPrefix } from "gatsby";
+import withStyles from '@material-ui/styles/withStyles';
 
 const AutoPlaySwipeableViews = autoPlay(SwipeableViews);
+
+const styles = {
+  cardMedia: {
+    height: "200px"
+  }
+};
 
 class Carousel extends React.Component {
   state = {
@@ -36,7 +42,7 @@ class Carousel extends React.Component {
 
   render() {
     const { activeStep } = this.state,
-      { items } = this.props,
+      { classes, items } = this.props,
       maxSteps = items.length;
     return (
       <Paper elevation={0}>
@@ -64,7 +70,7 @@ class Carousel extends React.Component {
                   {Math.abs(activeStep - index) <= 2 ? (
                     <Card>
                       <CardMedia
-                        style={{ height: "200px" }}
+                        className={classes.cardMedia}
                         image={withPrefix(publicURL)}
                       />
                       <CardContent>
@@ -108,4 +114,4 @@ class Carousel extends React.Component {
   }
 }
 
-export default Carousel;
+export default withStyles(styles)(Carousel);

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -3,17 +3,36 @@ import { StaticQuery, graphql } from "gatsby";
 import Divider from "@material-ui/core/Divider";
 import Typography from "@material-ui/core/Typography";
 import Hidden from "@material-ui/core/Hidden";
+import withStyles from '@material-ui/styles/withStyles';
 
-const Footer = props => {
+const styles = theme => ({
+  divider: {
+    marginTop: theme.spacing.unit * 6,
+    marginBottom: theme.spacing.unit * 3,
+  },
+  footer: {
+    marginBottom: theme.spacing.unit * 3,
+    whiteSpace: 'nowrap',
+  }
+});
+
+const Footer = withStyles(styles)(props => {
   const {
-    title,
-    contact: { email, phone },
-  } = props.data.site.siteMetadata;
+    classes,
+    data: {
+      site: {
+        siteMetadata: {
+          title,
+          contact: { email, phone },
+        },
+      },
+    },
+  } = props;
   return (
     <>
-      <Divider style={{ marginTop: "48px", marginBottom: "24px" }} />
+      <Divider className={classes.divider} />
       <footer
-        style={{ marginBottom: "24px", whiteSpace: "nowrap" }}
+        className={classes.footer}
         id="footer"
       >
         <span>
@@ -34,7 +53,7 @@ const Footer = props => {
       </footer>
     </>
   );
-};
+});
 
 export default props => (
   <StaticQuery

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -26,9 +26,9 @@ const Header = props => {
             <Chip
               id="logo"
               variant="outlined"
-              avatar=<Avatar id="logoIcon">
+              avatar={<Avatar id="logoIcon">
                 <MaterialUi />
-              </Avatar>
+              </Avatar>}
               label={
                 <Link to="/">
                   {props.data.site.siteMetadata.title.toUpperCase()}
@@ -39,7 +39,6 @@ const Header = props => {
           <Grid item>
             <Hidden smDown>
               <Typography
-                style={{ color: "#efefef", flex: 1 }}
                 component="span"
                 variant="caption"
               >

--- a/src/components/HomeFeatures.js
+++ b/src/components/HomeFeatures.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import Chip from "@material-ui/core/Chip";
 import Grid from "@material-ui/core/Grid";
 import Avatar from "@material-ui/core/Avatar";
-import { withStyles } from "@material-ui/core/styles";
+import withStyles from "@material-ui/styles/withStyles";
 import { Robot } from "mdi-material-ui";
 
 const styles = theme => ({
@@ -63,8 +63,7 @@ const styles = theme => ({
   };
 
 HomeFeatures.propTypes = {
-  classes: PropTypes.object.isRequired,
-  theme: PropTypes.object.isRequired,
+  classes: PropTypes.object.isRequired
 };
 
-export default withStyles(styles, { withTheme: true })(HomeFeatures);
+export default withStyles(styles)(HomeFeatures);

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -6,8 +6,16 @@ import CardContent from "@material-ui/core/CardContent";
 import CardMedia from "@material-ui/core/CardMedia";
 import Typography from "@material-ui/core/Typography";
 import { withPrefix } from "gatsby";
+import withStyles from "@material-ui/styles/withStyles";
+
+const styles = {
+  cardMedia: {
+    height: "200px"
+  }
+};
 
 const List = props => {
+  const { classes } = props;
   return (
     <Grid
       spacing={24}
@@ -31,7 +39,7 @@ const List = props => {
           <Grid item xs={12} md={6} key={path}>
             <Card>
               <CardMedia
-                style={{ height: "200px" }}
+                className={classes.cardMedia}
                 image={withPrefix(publicURL)}
               />
               <CardContent>
@@ -48,4 +56,4 @@ const List = props => {
   );
 };
 
-export default List;
+export default withStyles(styles)(List);

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -3,14 +3,28 @@ import { StaticQuery, Link, graphql } from "gatsby";
 import Button from "@material-ui/core/Button";
 import IconButton from "@material-ui/core/IconButton";
 import { GithubCircle } from "mdi-material-ui";
+import withStyles from "@material-ui/styles/withStyles";
 
-const Menu = props => {
-  const { menuLinks } = props.data.site.siteMetadata;
+const styles = theme => ({
+  menuButton: {
+    color: theme.palette.primary.contrastText
+  }
+});
+
+const Menu = withStyles(styles)(props => {
+  const {
+    classes,
+    data: {
+      site: {
+        siteMetadata: { menuLinks }
+      }
+    }
+  } = props;
   return (
     <>
       {menuLinks.map(link => (
         <Link key={link.name} to={link.link}>
-          <Button style={{ color: "#fff" }}>{link.name}</Button>
+          <Button className={classes.menuButton}>{link.name}</Button>
         </Link>
       ))}
       <a
@@ -18,13 +32,13 @@ const Menu = props => {
         target="_blank"
         rel="noopener noreferrer"
       >
-        <IconButton style={{ color: "#fff" }}>
+        <IconButton className={classes.menuButton}>
           <GithubCircle />
         </IconButton>
       </a>
     </>
   );
-};
+});
 
 export default props => (
   <StaticQuery

--- a/src/components/MenuMobile.js
+++ b/src/components/MenuMobile.js
@@ -5,6 +5,13 @@ import MenuItem from "@material-ui/core/MenuItem";
 import ClickAwayListener from "@material-ui/core/ClickAwayListener";
 import IconButton from "@material-ui/core/IconButton";
 import { DotsVertical } from "mdi-material-ui";
+import withStyles from "@material-ui/styles/withStyles";
+
+const styles = {
+  dotsVerticalIcon: {
+    color: "#efefef"
+  }
+};
 
 class MenuMobile extends React.Component {
   state = {
@@ -20,12 +27,21 @@ class MenuMobile extends React.Component {
   };
 
   render() {
-    const { anchorEl } = this.state,
-      { menuLinks } = this.props.data.site.siteMetadata;
+    const { anchorEl } = this.state;
+    const {
+      classes,
+      data: {
+        site: {
+          siteMetadata: {
+            menuLinks
+          }
+        }
+      }
+    } = this.props;
     return (
       <>
         <IconButton onClick={this.handleOpen}>
-          <DotsVertical style={{ color: "#efefef" }} />
+          <DotsVertical className={classes.dotsVerticalIcon} />
         </IconButton>
         <ClickAwayListener onClickAway={this.handleClose}>
           <Menu
@@ -52,6 +68,8 @@ class MenuMobile extends React.Component {
   }
 }
 
+const StyledMenuMobile = withStyles(styles)(MenuMobile);
+
 export default props => (
   <StaticQuery
     query={graphql`
@@ -66,6 +84,6 @@ export default props => (
         }
       }
     `}
-    render={data => <MenuMobile active={props.active} data={data} />}
+    render={data => <StyledMenuMobile active={props.active} data={data} />}
   />
 );

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -2,32 +2,43 @@ import React from "react";
 import Header from "./Header";
 import Footer from "./Footer";
 import { Grid, Typography } from "@material-ui/core";
+import withStyles from "@material-ui/styles/withStyles";
 import "../css/style.styl";
+
+const styles = {
+  container: {
+    marginTop: 94,
+  },
+  contentBox: {
+    maxWidth: "calc(1136px - 60px)",
+    width: "calc(100% - 60px)",
+  },
+  title: {
+    textAlign: "center"
+  }
+};
 
 class Page extends React.Component {
   render() {
-    const { title, children } = this.props;
+    const { classes, title, children } = this.props;
     return (
       <>
         <Header />
         <Grid
+          className={classes.container}
           container
           direction="row"
           justify="center"
-          style={{ marginTop: 94 }}
         >
           <Grid
+            className={classes.contentBox}
             item
-            style={{
-              maxWidth: "calc(1136px - 60px)",
-              width: "calc(100% - 60px)",
-            }}
           >
             {title ? (
               <Typography
+                className={classes.title}
                 variant="h2"
                 gutterBottom
-                style={{ textAlign: "center" }}
               >
                 {title}
               </Typography>
@@ -41,4 +52,4 @@ class Page extends React.Component {
   }
 }
 
-export default Page;
+export default withStyles(styles)(Page);

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,6 +1,6 @@
+import withRoot from "../utils/withRoot";
 import React from "react";
 import Page from "../components/Page";
-import withRoot from "../utils/withRoot";
 
 class NotFoundPage extends React.Component {
   render() {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,7 +9,7 @@ import Button from "@material-ui/core/Button";
 import Carousel from "../components/Carousel";
 import Avatar from "@material-ui/core/Avatar";
 import { Gift } from "mdi-material-ui";
-import { withStyles } from "@material-ui/core/styles";
+import withStyles from "@material-ui/styles/withStyles";
 import withRoot from "../utils/withRoot";
 
 const styles = theme => ({

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,3 +1,4 @@
+import withRoot from "../utils/withRoot";
 import React from "react";
 import { graphql, Link } from "gatsby";
 import PropTypes from "prop-types";
@@ -10,7 +11,6 @@ import Carousel from "../components/Carousel";
 import Avatar from "@material-ui/core/Avatar";
 import { Gift } from "mdi-material-ui";
 import withStyles from "@material-ui/styles/withStyles";
-import withRoot from "../utils/withRoot";
 
 const styles = theme => ({
     root: {
@@ -37,15 +37,15 @@ const styles = theme => ({
             </Avatar>
           }
           action={
-            <>
-              <Button
-                variant="contained"
-                color="secondary"
-                className={props.classes.root}
-              >
-                <Link to="/products">View All Products</Link>
-              </Button>
-            </>
+            <Button
+              variant="contained"
+              color="secondary"
+              className={props.classes.root}
+              component={Link}
+              to="/products"
+            >
+              View All Products
+            </Button>
           }
           style={{ minHeight: 523 }}
         >

--- a/src/pages/products/index.js
+++ b/src/pages/products/index.js
@@ -1,9 +1,9 @@
+import withRoot from "../../utils/withRoot";
 import React from "react";
 import { graphql } from "gatsby";
 import SEO from "../../components/SEO";
 import Page from "../../components/Page";
 import List from "../../components/List";
-import withRoot from "../../utils/withRoot";
 
 const Products = props => {
   const products = props.data.allMarkdownRemark.edges;

--- a/src/pages/team/index.js
+++ b/src/pages/team/index.js
@@ -1,5 +1,6 @@
+import withRoot from "../../utils/withRoot";
 import React from "react";
-import { Link, graphql } from "gatsby";
+import { Link, graphql, withPrefix } from "gatsby";
 import Typography from "@material-ui/core/Typography";
 import SEO from "../../components/SEO";
 import Page from "../../components/Page";
@@ -8,8 +9,6 @@ import GridListTile from "@material-ui/core/GridListTile";
 import GridListTileBar from "@material-ui/core/GridListTileBar";
 import IconButton from "@material-ui/core/IconButton";
 import { Rocket } from "mdi-material-ui";
-import withRoot from "../../utils/withRoot";
-import { withPrefix } from "gatsby";
 
 const Team = props => {
   const teams = props.data.allMarkdownRemark.edges;

--- a/src/templates/general.js
+++ b/src/templates/general.js
@@ -8,8 +8,15 @@ import CardMedia from "@material-ui/core/CardMedia";
 import Typography from "@material-ui/core/Typography";
 import withRoot from "../utils/withRoot";
 import { withPrefix } from "gatsby";
+import withStyles from "@material-ui/styles/withStyles";
 
-const Detail = ({ data }) => {
+const styles = {
+  cardMedia: {
+    height: "200px"
+  }
+};
+
+const Detail = ({ classes, data }) => {
   const {
       title,
       image: { publicURL },
@@ -19,7 +26,7 @@ const Detail = ({ data }) => {
     <Page>
       <SEO title={title} />
       <Card>
-        <CardMedia style={{ height: "200px" }} image={withPrefix(publicURL)} />
+        <CardMedia className={classes.cardMedia} image={withPrefix(publicURL)} />
         <CardContent>
           <Typography gutterBottom variant="h2" component="h2">
             {title}
@@ -46,4 +53,4 @@ export const query = graphql`
   }
 `;
 
-export default withRoot(Detail);
+export default withRoot(withStyles(styles)(Detail));

--- a/src/templates/general.js
+++ b/src/templates/general.js
@@ -1,3 +1,4 @@
+import withRoot from "../utils/withRoot";
 import React from "react";
 import { graphql } from "gatsby";
 import SEO from "../components/SEO";
@@ -6,7 +7,6 @@ import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import CardMedia from "@material-ui/core/CardMedia";
 import Typography from "@material-ui/core/Typography";
-import withRoot from "../utils/withRoot";
 import { withPrefix } from "gatsby";
 import withStyles from "@material-ui/styles/withStyles";
 

--- a/src/templates/team.js
+++ b/src/templates/team.js
@@ -7,8 +7,18 @@ import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
 import withRoot from "../utils/withRoot";
 import { withPrefix } from "gatsby";
+import withStyles from "@material-ui/styles/withStyles";
 
-const Detail = ({ data }) => {
+const styles = {
+  paper: {
+    padding: "25px"
+  },
+  image: {
+    width: "100%"
+  }
+};
+
+const Detail = ({ classes, data }) => {
   const {
       title,
       image: { publicURL },
@@ -18,7 +28,7 @@ const Detail = ({ data }) => {
   return (
     <Page>
       <SEO title={title} />
-      <Paper style={{ padding: "25px" }}>
+      <Paper className={classes.paper}>
         <Grid
           spacing={24}
           container
@@ -27,7 +37,7 @@ const Detail = ({ data }) => {
           justify="center"
         >
           <Grid item xs={12} md={4}>
-            <img style={{ width: "100%" }} src={withPrefix(publicURL)} alt="" />
+            <img className={classes.classes} src={withPrefix(publicURL)} alt="" />
           </Grid>
           <Grid item xs={12} md={8}>
             <Typography gutterBottom variant="h2" component="h2">
@@ -60,4 +70,4 @@ export const query = graphql`
   }
 `;
 
-export default withRoot(Detail);
+export default withRoot(withStyles(styles)(Detail));

--- a/src/templates/team.js
+++ b/src/templates/team.js
@@ -1,3 +1,4 @@
+import withRoot from "../utils/withRoot";
 import React from "react";
 import { graphql } from "gatsby";
 import SEO from "../components/SEO";
@@ -5,7 +6,6 @@ import Page from "../components/Page";
 import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
-import withRoot from "../utils/withRoot";
 import { withPrefix } from "gatsby";
 import withStyles from "@material-ui/styles/withStyles";
 
@@ -37,7 +37,7 @@ const Detail = ({ classes, data }) => {
           justify="center"
         >
           <Grid item xs={12} md={4}>
-            <img className={classes.classes} src={withPrefix(publicURL)} alt="" />
+            <img className={classes.image} src={withPrefix(publicURL)} alt="" />
           </Grid>
           <Grid item xs={12} md={8}>
             <Typography gutterBottom variant="h2" component="h2">

--- a/src/utils/getPageContext.js
+++ b/src/utils/getPageContext.js
@@ -1,9 +1,7 @@
 // See https://github.com/mui-org/material-ui/tree/master/examples/gatsby
 import { SheetsRegistry } from "jss";
-import {
-  createMuiTheme,
-  createGenerateClassName,
-} from "@material-ui/core/styles";
+import { createMuiTheme } from "@material-ui/core/styles";
+import { createGenerateClassName } from '@material-ui/styles';
 import purple from "@material-ui/core/colors/purple";
 import green from "@material-ui/core/colors/green";
 

--- a/src/utils/installMuiStyles.js
+++ b/src/utils/installMuiStyles.js
@@ -1,0 +1,5 @@
+import { install } from '@material-ui/styles';
+
+install();
+// These two lines are in a separate file so that 'install()' call can happen before anything is imported from material-ui libs.
+// https://material-ui.com/css-in-js/basics/#migration-for-material-ui-core-users

--- a/src/utils/withRoot.js
+++ b/src/utils/withRoot.js
@@ -1,8 +1,8 @@
 // See https://github.com/mui-org/material-ui/tree/master/examples/gatsby
 import React from "react";
-import { MuiThemeProvider } from "@material-ui/core/styles";
+import './installMuiStyles';
+import { ThemeProvider } from "@material-ui/styles";
 import CssBaseline from "@material-ui/core/CssBaseline";
-import JssProvider from "react-jss/lib/JssProvider";
 import getPageContext from "./getPageContext";
 import Hidden from "@material-ui/core/Hidden";
 
@@ -23,20 +23,17 @@ function withRoot(Component) {
 
     render() {
       return (
-        <JssProvider generateClassName={this.muiPageContext.generateClassName}>
-          {/* MuiThemeProvider makes the theme available down the React
-              tree thanks to React context. */}
-          <MuiThemeProvider
-            theme={this.muiPageContext.theme}
-            sheetsManager={this.muiPageContext.sheetsManager}
-          >
-            {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-            <CssBaseline />
-            <Hidden implementation="css">
-              <Component {...this.props} />
-            </Hidden>
-          </MuiThemeProvider>
-        </JssProvider>
+        // ThemeProvider makes the theme available down the React
+        // tree thanks to React context.
+        <ThemeProvider
+          theme={this.muiPageContext.theme}
+        >
+          {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
+          <CssBaseline />
+          <Hidden implementation="css">
+            <Component {...this.props} />
+          </Hidden>
+        </ThemeProvider>
       );
     }
   }

--- a/src/utils/withRoot.js
+++ b/src/utils/withRoot.js
@@ -1,7 +1,7 @@
 // See https://github.com/mui-org/material-ui/tree/master/examples/gatsby
-import React from "react";
 import './installMuiStyles';
-import { ThemeProvider } from "@material-ui/styles";
+import React from "react";
+import { StylesProvider, ThemeProvider } from "@material-ui/styles";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import getPageContext from "./getPageContext";
 import Hidden from "@material-ui/core/Hidden";
@@ -23,17 +23,22 @@ function withRoot(Component) {
 
     render() {
       return (
-        // ThemeProvider makes the theme available down the React
-        // tree thanks to React context.
-        <ThemeProvider
-          theme={this.muiPageContext.theme}
+        <StylesProvider
+          generateClassName={this.muiPageContext.generateClassName}
+          sheetsManager={this.muiPageContext.sheetsManager}
         >
-          {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-          <CssBaseline />
-          <Hidden implementation="css">
-            <Component {...this.props} />
-          </Hidden>
-        </ThemeProvider>
+          {/* ThemeProvider makes the theme available down the React
+          tree thanks to React context. */}
+          <ThemeProvider
+            theme={this.muiPageContext.theme}
+          >
+            {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
+            <CssBaseline />
+            <Hidden implementation="css">
+              <Component {...this.props} />
+            </Hidden>
+          </ThemeProvider>
+        </StylesProvider>
       );
     }
   }


### PR DESCRIPTION
This PR may be premature as @material-ui/styles is still in alpha. However, it may become useful as:
- @material-ui/core/styles is being deprecated in material-ui v4.
- New API includes hooks implementation (useStyles, useTheme) which is great if you like React hooks.
New API spec: https://material-ui.com/css-in-js/basics